### PR TITLE
Add grunt-init install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ You can use Sass, LESS or plain-CSS editing and choose from includes like Bootst
 [grunt-init]: http://gruntjs.com/project-scaffolding
 
 ## Installation
-If you haven't already done so, install [grunt-init][].
+If you haven't already done so, install [grunt-init][]:
+
+```
+npm install -g grunt-init
+```
 
 Once grunt-init is installed, place this template in your `~/.grunt-init/` directory. It's recommended that you use git to clone this template into that directory, as follows:
 


### PR DESCRIPTION
From looking at the installation page (https://gruntjs.com/project-scaffolding), there's only one way recommended to install. So makes sense to probably include it here to simplify initial setup.